### PR TITLE
update to ArrayInterface 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["gregoirepourtier <gpourtier@icloud.com>"]
 version = "0.1.2"
 
 [deps]
-ArrayInterfaceBandedMatrices = "2e50d22c-5be1-4042-81b1-c572ed69783d"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -19,7 +18,7 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ArrayInterfaceBandedMatrices = "0.1"
+ArrayInterface = "7"
 BandedMatrices = "0.17"
 DifferentialEquations = "7.6"
 DocStringExtensions = "0.9"
@@ -31,3 +30,6 @@ Reexport = "1"
 SparseDiffTools = "1.30"
 StaticArrays = "1.5"
 julia = "1.6"
+
+[weakdeps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["gregoirepourtier <gpourtier@icloud.com>"]
 version = "0.1.2"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -30,6 +31,3 @@ Reexport = "1"
 SparseDiffTools = "1.30"
 StaticArrays = "1.5"
 julia = "1.6"
-
-[weakdeps]
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/SkeelBerzins.jl
+++ b/src/SkeelBerzins.jl
@@ -15,9 +15,6 @@ using Reexport
 @reexport using LinearSolve
 @reexport using StaticArrays
 
-# see https://github.com/JuliaDiff/SparseDiffTools.jl#note-about-sparse-differentiation-of-gpuarrays-bandedmatrices-and-blockbandedmatrices
-using ArrayInterfaceBandedMatrices
-
 include("pdepe.jl")
 export pdepe
 


### PR DESCRIPTION
As long as you are on ArrayInterface 7, then the package extensions feature of Julia will auto-load the required extension package and thus it's no longer needed to be using'ed here.